### PR TITLE
Find correct library automagically on Darwin

### DIFF
--- a/libusb-ffi.lisp
+++ b/libusb-ffi.lisp
@@ -3,6 +3,7 @@
 (in-package #:libusb-ffi)
 
 (define-foreign-library libusb
+  (:darwin (:or (:default "libusb") (:default "libusb-legacy")))
   (:bsd "libusb-legacy-0.1.4.4.4.dylib")
   (:unix (:or "libusb-0.1.so.4.4" "libusb-0.1.so.4" "libusb-0.1.so"))
   (:windows "libusb0")


### PR DESCRIPTION
Tested with Homebrew

Apparently the libusb-legacy version is used with MacPorts, which is why it's left in here
Should be possible to remove the :bsd line. Someone with MacPorts can try.